### PR TITLE
feat: 투두 리스트 추가 스크린 작성

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/cksckckcks/downloadifyoucan/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/cksckckcks/downloadifyoucan/MainActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.cksckckcks.downloadifyoucan.ui.screen.MainScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -14,7 +13,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            MainScreen()
+            AppAndroidPreview()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/theme/Color.kt
+++ b/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/theme/Color.kt
@@ -8,3 +8,5 @@ val MainColor = Color(0xFF1663A6)
 
 val SubBackgroundColor = Color(0xFFF3F4F6)
 val SubFontColor = Color(0xFF6B7280)
+
+val TextGray = Color(0xFFA9A9A9)

--- a/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/component/Calendar.kt
+++ b/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/component/Calendar.kt
@@ -1,0 +1,133 @@
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.cksckckcks.downloadifyoucan.theme.MainColor
+import com.cksckckcks.downloadifyoucan.theme.pretendard
+import kotlinx.datetime.*
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+
+@Preview(showBackground = true)
+@Composable
+fun Calendar(
+    today: LocalDate = LocalDate(2025,11,1),
+    selectedDate: LocalDate = LocalDate(2025,11,1)
+) {
+    val pagerState = rememberPagerState(pageCount = { 12 })
+
+    HorizontalPager(
+        state = pagerState,
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) { page ->
+        val monthOffset = page
+        val targetDate = today.plus(monthOffset, DateTimeUnit.MONTH)
+        val pageYear = targetDate.year
+        val pageMonth = targetDate.monthNumber
+
+        val firstDayOfMonth = LocalDate(pageYear, pageMonth, 1)
+        val dayOfWeek = firstDayOfMonth.dayOfWeek.isoDayNumber
+        val daysInMonth = firstDayOfMonth.daysUntil(
+            firstDayOfMonth.plus(1, DateTimeUnit.MONTH)
+        )
+
+        val days = mutableListOf<LocalDate?>()
+
+        if (dayOfWeek != 7) {
+            repeat(dayOfWeek) { days.add(null) }
+        }
+
+        for (day in 1..daysInMonth) {
+            days.add(LocalDate(pageYear, pageMonth, day))
+        }
+
+        while (days.size % 7 != 0) {
+            days.add(null)
+        }
+
+        val weeks = days.chunked(7)
+
+        Column {
+            Text(
+                text = "${pageYear}년 ${pageMonth}월",
+                fontFamily = pretendard(),
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            weeks.forEach { week ->
+                WeekRow(
+                    week = week,
+                    selectedDate = selectedDate,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun WeekRow(
+    week: List<LocalDate?>,
+    selectedDate: LocalDate,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        week.forEach { date ->
+            DayBox(
+                date = date,
+                selectedDate = selectedDate
+            )
+        }
+    }
+}
+
+@Composable
+fun DayBox(
+    date: LocalDate?,
+    selectedDate: LocalDate
+) {
+    val selected = date == selectedDate
+
+    Box(
+        modifier = Modifier
+            .size(38.dp)
+            .padding(vertical = 2.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    color = if (selected) MainColor else Color.Transparent,
+                    shape = RectangleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = date?.dayOfMonth?.toString() ?: "",
+                fontFamily = pretendard(),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Normal,
+                textAlign = TextAlign.Center,
+                color = if (selected) Color.White else Color.Black,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/component/MainButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/component/MainButton.kt
@@ -1,0 +1,48 @@
+package com.cksckckcks.downloadifyoucan.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.cksckckcks.downloadifyoucan.theme.MainColor
+import com.cksckckcks.downloadifyoucan.theme.pretendard
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+
+@Preview(showBackground = true)
+@Composable
+fun MainButton(
+    modifier: Modifier = Modifier,
+    text: String = "Button",
+    buttonClick: () -> Unit = {}
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(5.dp))
+            .background(MainColor)
+            .clickable { buttonClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            fontFamily = pretendard(),
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 20.sp,
+            color = Color.White,
+            modifier = Modifier
+                .padding(vertical = 20.dp)
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/component/MainInputField.kt
+++ b/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/component/MainInputField.kt
@@ -1,0 +1,89 @@
+package com.cksckckcks.downloadifyoucan.ui.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.cksckckcks.downloadifyoucan.theme.MainColor
+import com.cksckckcks.downloadifyoucan.theme.TextGray
+import com.cksckckcks.downloadifyoucan.theme.pretendard
+
+
+@Composable
+fun MainInputField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String = "입력해주세요",
+    singleLine: Boolean = true,
+//    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+//    keyboardActions: KeyboardActions = KeyboardActions.Default,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+    ) {
+        Row (
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            BasicTextField(
+                value = value,
+                onValueChange = onValueChange,
+                singleLine = singleLine,
+                textStyle = TextStyle(
+                    color = Color.Black,
+                    fontFamily = pretendard(),
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Normal
+                ),
+//                keyboardOptions = keyboardOptions,
+//                keyboardActions = keyboardActions,
+                decorationBox = { innerTextField ->
+                    if (value.isEmpty()) {
+                        Text(
+                            text = placeholder,
+                            style = TextStyle(
+                                color = TextGray,
+                                fontFamily = pretendard(),
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.Normal,
+                            ),
+                            textAlign = TextAlign.Start,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    innerTextField()
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 2.dp, top = 15.dp, bottom = 15.dp)
+            )
+
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+        ) {
+            HorizontalDivider(
+                thickness = 1.dp,
+                color = MainColor,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/component/PrioritySelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/component/PrioritySelector.kt
@@ -1,0 +1,42 @@
+package com.cksckckcks.downloadifyoucan.ui.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.cksckckcks.downloadifyoucan.model.Priority
+import com.cksckckcks.downloadifyoucan.theme.MainColor
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+
+@Preview(showBackground = true)
+@Composable
+fun PrioritySelector(
+    selectedPriority: Priority = Priority.MEDIUM
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Priority.entries.forEach { priority ->
+            val backgroundColor = if (priority == selectedPriority) MainColor.copy(0.3f) else Color.Unspecified
+            Image(
+                painter = painterResource(priority.image),
+                contentDescription = priority.name,
+                    modifier = Modifier
+                        .size(100.dp)
+                        .background(backgroundColor)
+            )
+        }
+    }
+
+}

--- a/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/component/SubTitleText.kt
+++ b/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/component/SubTitleText.kt
@@ -1,0 +1,19 @@
+package com.cksckckcks.downloadifyoucan.ui.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.cksckckcks.downloadifyoucan.theme.pretendard
+
+@Composable
+fun SubTitleText(
+    text: String
+) {
+    Text(
+        text = text,
+        fontFamily = pretendard(),
+        fontSize = 20.sp,
+        fontWeight = FontWeight.Medium
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/component/TitleText.kt
+++ b/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/component/TitleText.kt
@@ -1,0 +1,20 @@
+package com.cksckckcks.downloadifyoucan.ui.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.cksckckcks.downloadifyoucan.theme.pretendard
+
+
+@Composable
+fun TitleText(
+    text: String
+) {
+    Text(
+        text = text,
+        fontFamily = pretendard(),
+        fontSize = 30.sp,
+        fontWeight = FontWeight.Bold
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/screen/AddToDoScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/screen/AddToDoScreen.kt
@@ -1,0 +1,101 @@
+package com.cksckckcks.downloadifyoucan.ui.screen
+
+import Calendar
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.cksckckcks.downloadifyoucan.ui.component.MainButton
+import com.cksckckcks.downloadifyoucan.ui.component.MainInputField
+import com.cksckckcks.downloadifyoucan.ui.component.PrioritySelector
+import com.cksckckcks.downloadifyoucan.ui.component.SubTitleText
+import com.cksckckcks.downloadifyoucan.ui.component.TitleText
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+
+@Preview(showBackground = true)
+@OptIn(ExperimentalTime::class)
+@Composable
+fun AddToDoScreen(
+
+) {
+    val now: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault())
+
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.systemBars)
+            .padding(horizontal = 24.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 22.dp)
+        ) {
+            TitleText("할일 추가")
+
+            Spacer(modifier = Modifier.height(39.dp))
+
+            SubTitleText("날짜")
+            Spacer(modifier = Modifier.height(10.dp))
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                Calendar(
+                    today = now,
+                    selectedDate = now
+                )
+            }
+
+            Spacer(modifier = Modifier.height(21.dp))
+
+            SubTitleText("제목")
+            MainInputField(
+                value = "",
+                onValueChange = {},
+                placeholder = "할일을 입력하세요",
+                singleLine = true
+            )
+
+            Spacer(modifier = Modifier.height(21.dp))
+
+            SubTitleText("세부내용")
+            MainInputField(
+                value = "",
+                onValueChange = {},
+                placeholder = "할일을 입력하세요",
+                singleLine = false
+            )
+
+            Spacer(modifier = Modifier.height(21.dp))
+
+            SubTitleText("급함 정도")
+            PrioritySelector()
+
+            Spacer(modifier = Modifier.height(21.dp))
+
+            MainButton(text = "할일 추가하기")
+
+        }
+    }
+}
+


### PR DESCRIPTION
## 작업 동기 및 이슈
- #4 

## 추가 및 변경사항
- 투두 리스트 추가 스크린 작성
- 타이틀, 캘린더, InputField, 급함 정도 선택, 메인 버튼 컴포넌트 작성
- compose app의 시작점이 app이 아닌 MainScreen으로 하드코딩 되어있던 부분 수정

## 기타

## 실행 화면
<img width="938" height="1023" alt="스크린샷 2025-11-14 오전 3 08 10" src="https://github.com/user-attachments/assets/9758fe35-284d-460a-978e-6b8dfcc4968d" />


