### PR TITLE
feat: 메인스크린 -> 할 일 상세정보 스크린 내비게이션 연결

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/screen/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/screen/MainScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.cksckckcks.downloadifyoucan.model.ToDo
 import com.cksckckcks.downloadifyoucan.theme.MainColor
 import com.cksckckcks.downloadifyoucan.theme.pretendard
 import com.cksckckcks.downloadifyoucan.ui.component.ToDoCard
@@ -60,7 +61,8 @@ class MainScreen : Screen {
 
         MainScreenContent(
             viewModel = viewModel,
-            onAddClick = { navigator.push(AddToDoScreen()) }
+            onAddClick = { navigator.push(AddToDoScreen()) },
+            onToDoClick = { navigator.push(ToDoDetailScreen(it))}
         )
     }
 }
@@ -69,7 +71,8 @@ class MainScreen : Screen {
 @Composable
 fun MainScreenContent(
     viewModel: MainViewModel,
-    onAddClick: () -> Unit
+    onAddClick: () -> Unit,
+    onToDoClick: (ToDo) -> Unit
 ) {
     val localDateTime = Clock.System.now()
         .toLocalDateTime(TimeZone.currentSystemDefault())
@@ -153,7 +156,10 @@ fun MainScreenContent(
                 items(toDoList.size) { idx ->
                     val toDo = toDoList[idx]
 
-                    ToDoCard(toDoItem = toDo)
+                    ToDoCard(
+                        toDoItem = toDo,
+                        onCardClick = { onToDoClick(toDo) }
+                    )
 
 
                 }

--- a/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/screen/ToDoDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/screen/ToDoDetailScreen.kt
@@ -34,24 +34,14 @@ import com.cksckckcks.downloadifyoucan.ui.component.TitleText
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
-class ToDoDetailScreen : Screen {
+class ToDoDetailScreen(
+    private val todo: ToDo
+) : Screen {
     @Composable
     override fun Content() {
-        val navigator = LocalNavigator.currentOrThrow
-        val tmpToDo = ToDo(
-            id = 1,
-            title = "디자인하기",
-            description = "UI 완성하기\nUX신경쓰기\n123123123123123123123123123123123123",
-            year = 2025,
-            month = 11,
-            day = 24,
-            priority = Priority.MEDIUM,
-            isDone = false
-        )
+        val navigator = LocalNavigator.currentOrThrow // 수정하기 넘어갈 때 사용하자
 
-        ToDoDetailScreenContent(
-            todo = tmpToDo
-        )
+        ToDoDetailScreenContent(todo = todo)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/screen/ToDoDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/cksckckcks/downloadifyoucan/ui/screen/ToDoDetailScreen.kt
@@ -6,11 +6,14 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -53,6 +56,7 @@ fun ToDoDetailScreenContent(
     Scaffold(
         modifier = Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.systemBars)
     ) {
         Column(
             modifier = Modifier


### PR DESCRIPTION
## 작업 동기 및 이슈
- #17 

## 추가 및 변경사항
- 메인 스크린에서 ToDo 클릭 시 상세 정보 페이지로 이동하도록 내비게이션 연결
- ToDo 상세정보 스크린 시스템바 패딩 추가

## 기타

## 실행 화면

